### PR TITLE
25 installations by company size

### DIFF
--- a/installations_by_company_size/installations_by_company_size.py
+++ b/installations_by_company_size/installations_by_company_size.py
@@ -1,0 +1,172 @@
+# %% [markdown]
+# ## Number of installations by company size over time
+#
+# This notebook contains analysis to understand the counts and proportions of heat pumps installed by differently sized companies. We have used the MCS installations data, using annual installations per company, to produce a proxy for this. The research questions to answer are as follows:
+# 1. Which companies are the top 30 installers in Q1 2025 by installation count?
+# 2. Which companies are the top 10 installers in 2024 by installation count?
+# 3. What are the proportions of installations by differently sized companies over time?
+# 4. What are the counts of installations by differently sized companies over time?
+# 5. What is the breakdown of the number of companies per size bracket in 2024?
+#
+# This analysis uses the processed MCS installations data up to and including Q1 2025.
+
+# %%
+import polars as pl
+import matplotlib.pyplot as plt
+import numpy as np
+
+# %%
+installations_df = pl.read_parquet("s3://asf-daps/lakehouse/2025_Q1/processed/mcs/mcs_installations_250611-0.parquet")
+
+# %%
+installations_df = installations_df.drop("__index_level_0__").filter(
+    # Check if we want to include any other installation_type fields
+    pl.col("installation_type") == "Domestic",
+    pl.col("tech_type") != "Micro CHP",
+).with_columns(
+    # Drop duplicate rows - check that we should do this. Could these represent true multi-installs?
+    pl.col(pl.String).str.to_lowercase()
+).unique()
+
+# %%
+# This is to ensure the ranges show in the desired order on the plots
+order_of_ranges = {
+    "1-10": 0,
+    "11-50": 1,
+    "51-100": 2,
+    "101-365": 3,
+    "Over 365": 4
+}
+
+# %%
+# Aggregate the number of installations per installer company per year
+installations_per_installer_per_year = installations_df.group_by(["company_unique_id", "commission_year"]).len().rename({"len": "n_installations"}).with_columns(
+    (pl.col("n_installations") / pl.col("n_installations").sum().over("commission_year")).alias("proportion_of_total_installations_per_year"),
+    # Add ranges
+    pl.when(pl.col("n_installations") <= 10)
+    .then(pl.lit("1-10"))
+    # Both ends inclusive
+    .when(pl.col("n_installations").is_between(11, 50, closed="both"))
+    .then(pl.lit("11-50"))
+    .when(pl.col("n_installations").is_between(51, 100, closed="both"))
+    .then(pl.lit("51-100"))
+    .when(pl.col("n_installations").is_between(101, 365, closed="both"))
+    .then(pl.lit("101-365"))
+    .when(pl.col("n_installations") > 365)
+    .then(pl.lit("Over 365"))
+    .otherwise(pl.lit("error"))
+    .alias("n_installations_range")
+).with_columns(
+    pl.col("n_installations_range").replace(order_of_ranges).cast(pl.Int8).alias("range_order")
+).sort(by="range_order", descending=False)
+
+# %%
+# Top 30 installers in 2025 Q1
+installations_per_installer_per_year.filter(pl.col("commission_year") == 2025).with_columns(
+    (pl.col("proportion_of_total_installations_per_year") *100).round(3).alias("pc_of_total_installations_per_quarter")
+).sort(by="n_installations", descending=True).head(30).drop(["proportion_of_total_installations_per_year", "range_order", "n_installations_range"]).write_csv("top30_installers_q1_2025.csv")
+
+# Remove 2025 data for the rest of the analysis because we don't have a full year
+installations_per_installer_per_year = installations_per_installer_per_year.filter(pl.col("commission_year") != 2025)
+
+# %%
+# Top 10 installers in 2024
+installations_per_installer_per_year.filter(pl.col("commission_year") == 2024).with_columns(
+    (pl.col("proportion_of_total_installations_per_year") *100).round(3).alias("pc_of_total_installations_per_year")
+).sort(by="n_installations", descending=True).head(10).drop(["proportion_of_total_installations_per_year", "range_order", "n_installations_range"])
+
+# %%
+# Aggregate the number of installations per 'size' of installer company per year
+installations_per_size_per_year = installations_per_installer_per_year.group_by(["n_installations_range", "commission_year"]).agg(
+    pl.col("n_installations").sum(),
+    pl.col("range_order").first(),
+    pl.col("company_unique_id").n_unique().alias("n_companies")
+).with_columns(
+    (pl.col("n_installations") / pl.col("n_installations").sum().over(["commission_year"])).alias("proportion_of_total_installations_per_year")
+).sort(by=["range_order", "commission_year"])
+
+# %%
+# Show the proportions of installations by each group over time
+commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+
+# colour_map = {r: colour for r in order_of_ranges}
+def create_colour_map(cmap, n):
+    cm = plt.get_cmap(cmap)
+    pts = np.linspace(0, 1, n)
+    return [cm(pt) for pt in pts]
+
+colours = create_colour_map("viridis", len(order_of_ranges))
+
+fig = plt.figure(figsize=(12, 5))
+
+# Plot each time series
+for r, colour in zip(order_of_ranges, colours):
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plt.plot(plot_data["commission_year"], plot_data["proportion_of_total_installations_per_year"], color=colour, label=r)
+
+plt.title("Proportion of annual domestic heat pump installations by company installation count")
+plt.xlabel("Year")
+plt.ylabel("Proportion of total annual installations")
+plt.legend(title="Number of annual installations per company*")
+plt.xticks(commission_years)
+
+text = "*The groups represent the number of installations per year per company. " \
+"The lines in the plot will therefore represent different total numbers of companies in different years as the number of installations by individual companies grows."
+plt.figtext(
+    0.5, -0.06, text, wrap=True, horizontalalignment="center"
+)
+
+# %%
+# Show the count of installations over time
+commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+
+colours = create_colour_map("viridis", len(order_of_ranges))
+
+fig = plt.figure(figsize=(12, 5))
+
+for r, colour in zip(order_of_ranges, colours):
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plt.plot(plot_data["commission_year"], plot_data["n_installations"], color=colour, label=r)
+
+plt.title("Count of annual domestic heat pump installations by company installation count")
+plt.xlabel("Year")
+plt.ylabel("Count of total annual installations")
+plt.legend(title="Number of annual installations per company*")
+plt.xticks(commission_years)
+
+text = "*The groups represent the number of installations per year per company. " \
+"The lines in the plot will therefore represent different total numbers of companies in different years as the number of installations by individual companies grows."
+plt.figtext(
+    0.5, -0.06, text, wrap=True, horizontalalignment="center"
+)
+
+# %%
+# Show the counts of companies in each bracket over time
+commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+
+colours = create_colour_map("viridis", len(order_of_ranges))
+
+fig = plt.figure(figsize=(12, 5))
+
+for r, colour in zip(order_of_ranges, colours):
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plt.plot(plot_data["commission_year"], plot_data["n_companies"], color=colour, label=r)
+
+plt.title("Count of installer companies by number of annual installations per year")
+plt.xlabel("Year")
+plt.ylabel("Count of installer companies")
+plt.legend(title="Number of annual installations per company*")
+plt.xticks(commission_years)
+plt.show()
+
+# %%
+# Breakdown of companies per bracket in 2024
+installations_per_size_per_year.filter(pl.col("commission_year") == 2024).with_columns(
+    (pl.col("n_companies") / pl.col("n_companies").sum() * 100).alias("pc_of_companies")
+).select(
+    ['n_installations_range',
+ 'commission_year',
+ 'n_installations',
+ 'n_companies',
+ 'pc_of_companies']
+)

--- a/installations_by_company_size/installations_by_company_size.py
+++ b/installations_by_company_size/installations_by_company_size.py
@@ -1,13 +1,13 @@
 # %% [markdown]
 # ## Number of installations by company size over time
-#
+# 
 # This notebook contains analysis to understand the counts and proportions of heat pumps installed by differently sized companies. We have used the MCS installations data, using annual installations per company, to produce a proxy for this. The research questions to answer are as follows:
 # 1. Which companies are the top 30 installers in Q1 2025 by installation count?
 # 2. Which companies are the top 10 installers in 2024 by installation count?
 # 3. What are the proportions of installations by differently sized companies over time?
 # 4. What are the counts of installations by differently sized companies over time?
 # 5. What is the breakdown of the number of companies per size bracket in 2024?
-#
+# 
 # This analysis uses the processed MCS installations data up to and including Q1 2025.
 
 # %%
@@ -16,10 +16,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # %%
-installations_df = pl.read_parquet("s3://asf-daps/lakehouse/2025_Q1/processed/mcs/mcs_installations_250611-0.parquet")
+raw_installations_df = pl.read_parquet("s3://asf-daps/lakehouse/2025_Q1/processed/mcs/mcs_installations_250611-0.parquet")
 
 # %%
-installations_df = installations_df.drop("__index_level_0__").filter(
+raw_installations_df["installation_type"].value_counts()
+
+# %%
+installations_df = raw_installations_df.drop("__index_level_0__").filter(
     # Check if we want to include any other installation_type fields
     pl.col("installation_type") == "Domestic",
     pl.col("tech_type") != "Micro CHP",
@@ -30,6 +33,7 @@ installations_df = installations_df.drop("__index_level_0__").filter(
 
 # %%
 # This is to ensure the ranges show in the desired order on the plots
+# The buckets were selected based on manual inspection of the distribution of installations in 2024 and then sense-checked with the team
 order_of_ranges = {
     "1-10": 0,
     "11-50": 1,
@@ -40,25 +44,26 @@ order_of_ranges = {
 
 # %%
 # Aggregate the number of installations per installer company per year
-installations_per_installer_per_year = installations_df.group_by(["company_unique_id", "commission_year"]).len().rename({"len": "n_installations"}).with_columns(
-    (pl.col("n_installations") / pl.col("n_installations").sum().over("commission_year")).alias("proportion_of_total_installations_per_year"),
-    # Add ranges
-    pl.when(pl.col("n_installations") <= 10)
-    .then(pl.lit("1-10"))
-    # Both ends inclusive
-    .when(pl.col("n_installations").is_between(11, 50, closed="both"))
-    .then(pl.lit("11-50"))
-    .when(pl.col("n_installations").is_between(51, 100, closed="both"))
-    .then(pl.lit("51-100"))
-    .when(pl.col("n_installations").is_between(101, 365, closed="both"))
-    .then(pl.lit("101-365"))
-    .when(pl.col("n_installations") > 365)
-    .then(pl.lit("Over 365"))
-    .otherwise(pl.lit("error"))
-    .alias("n_installations_range")
-).with_columns(
-    pl.col("n_installations_range").replace(order_of_ranges).cast(pl.Int8).alias("range_order")
-).sort(by="range_order", descending=False)
+
+# Add ranges - both ends inclusive
+range_labels = ["1-10", "11-50", "51-100", "101-365", "Over 365"]
+range_breaks = [10, 50, 100, 365]
+
+installations_per_installer_per_year = (
+    installations_df.group_by(["company_unique_id", "commission_year"])
+    .len()
+    .rename({"len": "n_installations"})
+    .with_columns(
+        (pl.col("n_installations") / pl.col("n_installations").sum().over("commission_year"))
+        .alias("proportion_of_total_installations_per_year"),
+        pl.col("n_installations").cut(breaks=range_breaks, labels=range_labels).alias("n_installations_range"),
+    )
+    .with_columns(
+        pl.col("n_installations_range").replace(order_of_ranges).cast(pl.Int8).alias("range_order"),
+        pl.col("n_installations_range").cast(pl.String)
+    )
+    .sort(by="range_order", descending=False)
+)
 
 # %%
 # Top 30 installers in 2025 Q1
@@ -73,7 +78,7 @@ installations_per_installer_per_year = installations_per_installer_per_year.filt
 # Top 10 installers in 2024
 installations_per_installer_per_year.filter(pl.col("commission_year") == 2024).with_columns(
     (pl.col("proportion_of_total_installations_per_year") *100).round(3).alias("pc_of_total_installations_per_year")
-).sort(by="n_installations", descending=True).head(10).drop(["proportion_of_total_installations_per_year", "range_order", "n_installations_range"])
+).sort(by="n_installations", descending=True).head(10).drop(["proportion_of_total_installations_per_year", "range_order", "n_installations_range"]).write_csv("top10_installers_2024.csv")
 
 # %%
 # Aggregate the number of installations per 'size' of installer company per year
@@ -86,10 +91,10 @@ installations_per_size_per_year = installations_per_installer_per_year.group_by(
 ).sort(by=["range_order", "commission_year"])
 
 # %%
-# Show the proportions of installations by each group over time
-commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+# Show the proportions of installations by each group over time - line chart
+# commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+commission_years = np.arange(2013, 2025, 1)
 
-# colour_map = {r: colour for r in order_of_ranges}
 def create_colour_map(cmap, n):
     cm = plt.get_cmap(cmap)
     pts = np.linspace(0, 1, n)
@@ -101,7 +106,7 @@ fig = plt.figure(figsize=(12, 5))
 
 # Plot each time series
 for r, colour in zip(order_of_ranges, colours):
-    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r, pl.col("commission_year") >= 2013)
     plt.plot(plot_data["commission_year"], plot_data["proportion_of_total_installations_per_year"], color=colour, label=r)
 
 plt.title("Proportion of annual domestic heat pump installations by company installation count")
@@ -117,15 +122,52 @@ plt.figtext(
 )
 
 # %%
-# Show the count of installations over time
-commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+# Show proportions of installations by each group over time - same as above as area chart
+installations_per_size_per_year_from_2013 = installations_per_size_per_year.filter(pl.col("commission_year") >= 2013)
 
-colours = create_colour_map("viridis", len(order_of_ranges))
+proportions_wide = (
+    installations_per_size_per_year_from_2013
+    .pivot(
+        on="n_installations_range",
+        index="commission_year",
+        values="proportion_of_total_installations_per_year",
+    )
+    .fill_null(0)
+    .sort("commission_year")
+)
+
+commission_years = proportions_wide["commission_year"].to_numpy()
+stacked_proportions = [proportions_wide[r].to_numpy() for r in order_of_ranges]
 
 fig = plt.figure(figsize=(12, 5))
 
+plt.stackplot(
+    commission_years,
+    stacked_proportions,
+    colors=colours,
+    labels=list(order_of_ranges),
+)
+
+plt.title("Proportion of annual domestic heat pump installations by company installation count")
+plt.xlabel("Year")
+plt.ylabel("Proportion of total annual installations")
+plt.legend(title="Number of annual installations per company*", loc="upper left", bbox_to_anchor=(1.02, 1))
+plt.xticks(commission_years)
+plt.xlim(commission_years.min(), commission_years.max())
+plt.ylim(0, 1)
+
+text = "*The groups represent the number of installations per year per company. " \
+"The lines in the plot will therefore represent different total numbers of companies in different years as the number of installations by individual companies grows."
+plt.figtext(
+    0.5, -0.06, text, wrap=True, horizontalalignment="center"
+)
+
+# %%
+# Show the count of installations over time - line chart
+fig = plt.figure(figsize=(12, 5))
+
 for r, colour in zip(order_of_ranges, colours):
-    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r, pl.col("commission_year") >= 2013)
     plt.plot(plot_data["commission_year"], plot_data["n_installations"], color=colour, label=r)
 
 plt.title("Count of annual domestic heat pump installations by company installation count")
@@ -141,32 +183,71 @@ plt.figtext(
 )
 
 # %%
-# Show the counts of companies in each bracket over time
-commission_years = installations_per_size_per_year["commission_year"].unique().sort()
+# Show count of installations over time - same as above as area chart
+counts_wide = (
+    installations_per_size_per_year
+    .filter(pl.col("commission_year") >= 2013)
+    .pivot(
+        on="n_installations_range",
+        index="commission_year",
+        values="n_installations",
+    )
+    .fill_null(0)
+    .sort("commission_year")
+)
+
+commission_years = counts_wide["commission_year"].to_numpy()
+stacked_counts = [counts_wide[r].to_numpy() for r in order_of_ranges]
 
 colours = create_colour_map("viridis", len(order_of_ranges))
 
 fig = plt.figure(figsize=(12, 5))
 
+plt.stackplot(
+    commission_years,
+    stacked_counts,
+    colors=colours,
+    labels=list(order_of_ranges),
+)
+
+plt.title("Count of annual domestic heat pump installations by company installation count")
+plt.xlabel("Year")
+plt.ylabel("Count of total annual installations")
+plt.legend(title="Number of annual installations per company*", loc="upper left", bbox_to_anchor=(1.02, 1))
+plt.xticks(commission_years)
+plt.xlim(commission_years.min(), commission_years.max())
+
+text = "*The groups represent the number of installations per year per company. " \
+"The areas in the plot will therefore represent different total numbers of companies in different years as the number of installations by individual companies grows."
+plt.figtext(
+    0.5, -0.06, text, wrap=True, horizontalalignment="center"
+)
+
+# %%
+# Show the counts of companies in each bracket over time
+fig = plt.figure(figsize=(12, 5))
+
 for r, colour in zip(order_of_ranges, colours):
-    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r)
+    plot_data = installations_per_size_per_year.filter(pl.col("n_installations_range") == r, pl.col("commission_year") >= 2013)
     plt.plot(plot_data["commission_year"], plot_data["n_companies"], color=colour, label=r)
 
 plt.title("Count of installer companies by number of annual installations per year")
 plt.xlabel("Year")
 plt.ylabel("Count of installer companies")
-plt.legend(title="Number of annual installations per company*")
+plt.legend(title="Number of annual installations per company")
 plt.xticks(commission_years)
 plt.show()
 
 # %%
 # Breakdown of companies per bracket in 2024
 installations_per_size_per_year.filter(pl.col("commission_year") == 2024).with_columns(
-    (pl.col("n_companies") / pl.col("n_companies").sum() * 100).alias("pc_of_companies")
+    (pl.col("n_companies") / pl.col("n_companies").sum() * 100).round(2).alias("pc_of_companies"),
+    (pl.col("n_installations") / pl.col("n_installations").sum() * 100).round(2).alias("pc_of_installations")
 ).select(
     ['n_installations_range',
  'commission_year',
  'n_installations',
  'n_companies',
- 'pc_of_companies']
-)
+ 'pc_of_companies',
+ "pc_of_installations"]
+).write_csv("companies_per_bracket_in_2024.csv")

--- a/installations_by_company_size/installations_by_company_size.py
+++ b/installations_by_company_size/installations_by_company_size.py
@@ -92,7 +92,6 @@ installations_per_size_per_year = installations_per_installer_per_year.group_by(
 
 # %%
 # Show the proportions of installations by each group over time - line chart
-# commission_years = installations_per_size_per_year["commission_year"].unique().sort()
 commission_years = np.arange(2013, 2025, 1)
 
 def create_colour_map(cmap, n):

--- a/installations_by_company_size/requirements.txt
+++ b/installations_by_company_size/requirements.txt
@@ -1,0 +1,3 @@
+polars
+matplotlib
+numpy

--- a/installations_by_company_size/requirements.txt
+++ b/installations_by_company_size/requirements.txt
@@ -1,3 +1,4 @@
 polars
 matplotlib
 numpy
+jupytext


### PR DESCRIPTION
Fixes #25 

**Description**

This notebook contains analysis to understand the counts and proportions of heat pumps installed by differently sized companies. We have used the MCS installations data, using annual installations per company, to produce a proxy for this. The research questions to answer are as follows:
1. Which companies are the top 30 installers in Q1 2025 by installation count?
2. Which companies are the top 10 installers in 2024 by installation count?
3. What are the proportions of installations by differently sized companies over time?
4. What are the counts of installations by differently sized companies over time?
5. What is the breakdown of the number of companies per size bracket in 2024?

**Instructions for reviewer:**

**To run the code:**
- Checkout the branch and create a new environment, activate it, then install `requirements.txt`
- run `jupytext --to notebook installations_by_company_size/installations_by_company_size.py` to create the notebook
- run the notebook

**Please pay special attention to:**
- Please could you check I have applied manipulations correctly to answer the questions.
- Please could you let me know if you think there are other data processing steps that should happen before the analysis. I also plan to double check this with Sofia next week as she knows the MCS data the best.